### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -95,8 +95,16 @@
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
+				if (!(config.target instanceof jQuery)) {
+					// Sanitize config.target to prevent XSS
+					if (typeof config.target === 'string') {
+						// Ensure the string is treated as a CSS selector, not HTML
+						config.target = $(document).find(config.target);
+					} else {
+						// Fallback for non-string values (e.g., DOM elements)
+						config.target = $(config.target);
+					}
+				}
 
 		// Panel.
 


### PR DESCRIPTION
Potential fix for [https://github.com/Humblemonk/slkstories/security/code-scanning/1](https://github.com/Humblemonk/slkstories/security/code-scanning/1)

To fix the issue, we need to ensure that `config.target` is sanitized before it is used to create a jQuery object. Specifically:
1. Use a safe method to validate or sanitize `config.target` to ensure it cannot be interpreted as HTML.
2. Replace the incorrect type check (`typeof config.target != 'jQuery'`) with a reliable check to determine if `config.target` is already a jQuery object.
3. If `config.target` is not a jQuery object, ensure it is treated strictly as a CSS selector or DOM element, and not as raw HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
